### PR TITLE
Fixed Finalize memory crashing bug issue #21

### DIFF
--- a/cmd/pcloudcc/control_tools.cpp
+++ b/cmd/pcloudcc/control_tools.cpp
@@ -88,7 +88,7 @@ int stop_crypto() {
 
 int finalize() {
   int ret;
-  char *errm;
+  char *errm = (char *)calloc(MAX_STRING_SIZE , sizeof(char));
 
   if (SendCall(FINALIZE, "", &ret, &errm)) {
     std::cout << "Finalize failed. return is " << ret << " and message is "

--- a/cmd/pcloudcc/control_tools.h
+++ b/cmd/pcloudcc/control_tools.h
@@ -29,6 +29,7 @@
 #ifndef CONTROL_TOOLS_H
 #define CONTROL_TOOLS_H
 
+#define MAX_STRING_SIZE 1024
 namespace control_tools {
 
 int start_crypto(const char *pass);


### PR DESCRIPTION
The fix is pretty easy you just have to make sure that the data pointed to by errm is valid by using malloc/calloc. the code would work if finalize call were to fail because the SendCall function would allocate a string that would write to errm. But in case of success like the example shown in the issue, it would not allocate memory for errm therefore freeing errm would try to free any garbage memory was left before creating the errm variable since it was uninitialized. This issue seems to only happen with the function call SendCall with the first parameter FINALIZE since i have trying asserting other calls like STOPCRYPTO but it seems that SendCall in other cases will allocate memory to the passed pointer even in case of success and no error messages to write.(this could be wrong since i don't have access to SendCall definition but it's one of the most logical conclusions.) 
Hope this helped !