### PR TITLE
fix: add missing include to make build work again

### DIFF
--- a/CLI11.hpp
+++ b/CLI11.hpp
@@ -394,4 +394,3 @@ namespace CLI {
 using App = ::App;
 using ParseError = ::ParseError;
 } // namespace CLI
-

--- a/CLI11.hpp
+++ b/CLI11.hpp
@@ -11,6 +11,7 @@ used by this program.
 #include <stdexcept>
 #include <string>
 #include <vector>
+#include <algorithm>
 
 // Forward declaration
 class ParseError : public std::runtime_error {

--- a/CLI11.hpp
+++ b/CLI11.hpp
@@ -4,6 +4,7 @@ used by this program.
 */
 
 #pragma once
+#include <algorithm>
 #include <functional>
 #include <iostream>
 #include <map>
@@ -11,7 +12,6 @@ used by this program.
 #include <stdexcept>
 #include <string>
 #include <vector>
-#include <algorithm>
 
 // Forward declaration
 class ParseError : public std::runtime_error {

--- a/CLI11.hpp
+++ b/CLI11.hpp
@@ -394,3 +394,4 @@ namespace CLI {
 using App = ::App;
 using ParseError = ::ParseError;
 } // namespace CLI
+


### PR DESCRIPTION
First of all, *thank you for your work*! 🙂 

I just noticed a little problem, probably caused by your latest cleanup in `CLI11.hpp`.

Trying to build the project using `make`, I get the following error:

```
In file included from control_tools.cpp:46:
CLI11.hpp: In member function ‘App::Subcommand* App::get_subcommand(const std::string&)’:
CLI11.hpp:171:20: error: no matching function for call to ‘find(std::vector<std::__cxx11::basic_string<char> >::iterator, std::vector<std::__cxx11::basic_string<char> >::iterator, const std::string&)’
  171 |       if (std::find(cmd.aliases.begin(), cmd.aliases.end(), name) !=
      |           ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

(...and some more of that one.)

It seems like `#include <algorithm>` is missing in `CLI11.hpp`. After I added it, the build worked again. 🙂 