### PR TITLE
#64 simplify messaging and #71 deserialize failed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@ a.out
 cmd/pcloudcc/build/pcloudcc
 **/*/.cache/
 compile_commands.json
-
+compile_commands.events.json
 /cmd/pcloudcc/build/
 /.cache/
 /lib/poverlay_linux/overlay_client

--- a/control_tools.cpp
+++ b/control_tools.cpp
@@ -41,7 +41,7 @@
 #include "pclsync/overlay_client.h"
 
 #include "pclsync_lib.h"
-#include "psynclib.h"
+#include "pclsync/psynclib.h"
 
 #include "CLI11.hpp"
 
@@ -59,56 +59,6 @@ enum command_ids_ {
   ADDSYNC,
   STOPSYNC
 };
-
-std::pair<std::string, std::string> split_paths(const std::string &input) {
-  std::string path1, path2;
-  bool in_quotes = false;
-  bool escaped = false;
-  std::string current_path;
-
-  for (char c : input) {
-    if (escaped) {
-      current_path += c;
-      escaped = false;
-    } else if (c == '\\') {
-      escaped = true;
-    } else if (c == '"') {
-      in_quotes = !in_quotes;
-      current_path += c;
-    } else if (c == ' ' && !in_quotes) {
-      if (!current_path.empty()) {
-        if (path1.empty()) {
-          path1 = current_path;
-        } else {
-          path2 = current_path;
-          break;
-        }
-        current_path.clear();
-      }
-    } else {
-      current_path += c;
-    }
-  }
-
-  if (!current_path.empty()) {
-    if (path1.empty()) {
-      path1 = current_path;
-    } else if (path2.empty()) {
-      path2 = current_path;
-    }
-  }
-
-  auto remove_quotes = [](std::string &s) {
-    if (s.size() >= 2 && s.front() == '"' && s.back() == '"') {
-      s = s.substr(1, s.size() - 2);
-    }
-  };
-
-  remove_quotes(path1);
-  remove_quotes(path2);
-
-  return {path1, path2};
-}
 
 int list_sync_folders() {
   int ret;

--- a/control_tools.cpp
+++ b/control_tools.cpp
@@ -105,6 +105,8 @@ int list_sync_folders() {
       rval = ret;
     }
     rval = ret;
+
+    free(flist);
   } else {
     std::cout << "failed to read folder list from shm" << std::endl;
     return -1;

--- a/doc/request-response.org
+++ b/doc/request-response.org
@@ -26,8 +26,7 @@ that gets created when the server is started.
   socket -> poverlay : request
   poverlay -> poverlay : poverlay_handle_request
   poverlay -> poverlay : poverlay_get_response
-  poverlay -> poverlay : serialize_response_message
-  poverlay -> socket : response (serialized)
+  poverlay -> socket : response
   socket -> overlay_client : read_response
   overlay_client -> control_tools : (msg, msgsz, payload, payloadsz)
   control_tools -> user : print results

--- a/pclsync/overlay_client.c
+++ b/pclsync/overlay_client.c
@@ -344,7 +344,7 @@ int read_response(int fd, char **out, size_t *out_size, int *ret,
     return -1;
   }
 
-  *out = malloc(value_size + 1);
+  *out = (char *)malloc(value_size + 1);
   if (*out == NULL) {
     const char *error_msg = "Memory allocation failed";
     *out = strdup(error_msg);

--- a/pclsync/overlay_client.c
+++ b/pclsync/overlay_client.c
@@ -62,7 +62,7 @@
 #include "overlay_client.h"
 #include "poverlay_protocol.h"
 
-#define POVERLAY_BUFSIZE 16 * 1024
+#define POVERLAY_BUFSIZE 512
 
 // for easier error tracing...
 #define POVERLAY_SOCKET_CREATE_FAILED -100
@@ -73,106 +73,8 @@
 #define POVERLAY_READ_INCOMPLETE -105
 #define POVERLAY_READ_INVALID_RESPONSE -106
 
-response_message *deserialize_response_message(const char *buffer,
-                                               size_t buffer_size) {
-  if (buffer_size < 2 * sizeof(size_t) + sizeof(uint32_t) + sizeof(uint64_t)) {
-    debug(D_ERROR, "Buffer size too small: %zu", buffer_size);
-    return NULL;
-  }
-
-  const char *ptr = buffer;
-
-  // Allocate response_message
-  response_message *resp = (response_message *)malloc(sizeof(response_message));
-  if (resp == NULL) {
-    debug(D_ERROR, "Failed to allocate response_message");
-    return NULL;
-  }
-
-  // Get message size
-  size_t msg_size = be64toh(*(size_t *)ptr);
-  ptr += sizeof(size_t);
-
-  debug(D_ERROR, "Message size: %zu", msg_size);
-
-  if (msg_size < sizeof(uint32_t) + sizeof(uint64_t)) {
-    debug(D_ERROR, "Invalid message size: %zu", msg_size);
-    free(resp);
-    return NULL;
-  }
-
-  // Allocate message with extra space for the flexible array member
-  size_t alloc_size =
-      sizeof(message) + msg_size - sizeof(uint32_t) - sizeof(uint64_t);
-  resp->msg = (message *)malloc(alloc_size);
-  if (resp->msg == NULL) {
-    debug(D_ERROR, "Failed to allocate message");
-    free(resp);
-    return NULL;
-  }
-
-  resp->msg->type = ntohl(*(uint32_t *)ptr);
-  ptr += sizeof(uint32_t);
-
-  resp->msg->length = be64toh(*(uint64_t *)ptr);
-  ptr += sizeof(uint64_t);
-
-  debug(D_ERROR, "Message type: %u, length: %lu", resp->msg->type,
-        resp->msg->length);
-
-  // Calculate the size of the value array
-  size_t value_size = msg_size - sizeof(uint32_t) - sizeof(uint64_t);
-
-  if (value_size > 0) {
-    if (ptr + value_size > buffer + buffer_size) {
-      debug(D_ERROR, "Buffer overflow detected");
-      free(resp->msg);
-      free(resp);
-      return NULL;
-    }
-    memcpy(resp->msg->value, ptr, value_size);
-    ptr += value_size;
-  }
-
-  // Deserialize payload size
-  if (ptr + sizeof(size_t) > buffer + buffer_size) {
-    debug(D_ERROR, "Buffer overflow detected when reading payload size");
-    free(resp->msg);
-    free(resp);
-    return NULL;
-  }
-  resp->payloadsz = be64toh(*(size_t *)ptr);
-  ptr += sizeof(size_t);
-
-  debug(D_ERROR, "Payload size: %zu", resp->payloadsz);
-
-  // Deserialize payload
-  if (resp->payloadsz > 0) {
-    if (ptr + resp->payloadsz > buffer + buffer_size) {
-      debug(D_ERROR, "Buffer overflow detected when reading payload");
-      free(resp->msg);
-      free(resp);
-      return NULL;
-    }
-    resp->payload = malloc(resp->payloadsz);
-    if (resp->payload == NULL) {
-      debug(D_ERROR, "Failed to allocate payload");
-      free(resp->msg);
-      free(resp);
-      return NULL;
-    }
-    memcpy(resp->payload, ptr, resp->payloadsz);
-  } else {
-    resp->payload = NULL;
-  }
-
-  return resp;
-}
-
-void free_response_message(response_message *resp) {
+void free_response_message(message *resp) {
   if (resp) {
-    free(resp->msg);
-    free(resp->payload);
     free(resp);
   }
 }
@@ -182,7 +84,7 @@ int QueryState(pCloud_FileState *state, char *path) {
   char *errm;
   size_t errm_size;
 
-  if (!SendCall(4, path /*IN*/, &rep, &errm, &errm_size, NULL, NULL)) {
+  if (!SendCall(4, path /*IN*/, &rep, &errm, &errm_size)) {
     debug(D_NOTICE, "QueryState responese rep[%d] path[%s]", rep, path);
     if (errm)
       debug(D_NOTICE, "The error is %s", errm);
@@ -243,15 +145,15 @@ int write_request(int fd, int msgtype, const char *value, char **out,
   int size;
   char *buf;
   const char *err;
-  request_message *request;
+  message *request;
   char *curbuf;
 
   *ret = 0; // Initialize ret to 0
 
   len = strlen(value);
-  size = sizeof(request_message) + len + 1;
+  size = sizeof(message) + len + 1;
   buf = (char *)malloc(size);
-  request = (request_message *)buf;
+  request = (message *)buf;
   memset(request, 0, size);
   request->type = msgtype;
   strncpy(request->value, value, len + 1);
@@ -288,122 +190,53 @@ int write_request(int fd, int msgtype, const char *value, char **out,
 // write an error message OR an API response value to out (and its
 // size to out_size), a "ret" value to ret (redundant?), and the
 // callback's return data to payload and payloadsz.
-int read_response(int fd, char **out, size_t *out_size, int *ret,
-                  void **payload, size_t *payloadsz) {
-  char buffer[POVERLAY_BUFSIZE];
-  ssize_t bytes_read = read(fd, buffer, POVERLAY_BUFSIZE);
+int read_response(int fd, char **out, size_t *out_size, int *ret) {
+    message *msg;
+    ssize_t bytes_read;
 
-  if (bytes_read <= 0) {
-    const char *error_msg =
-        (bytes_read == 0) ? "Connection closed" : strerror(errno);
-    *out = strdup(error_msg);
-    *out_size = strlen(error_msg) + 1;
-    *ret = -1;
-    return -1;
-  }
-
-  if (bytes_read < sizeof(response_message)) {
-    const char *error_msg = "Incomplete response";
-    *out = strdup(error_msg);
-    *out_size = strlen(error_msg) + 1;
-    *ret = -1;
-    return -1;
-  }
-
-  // response_message *resp = (response_message *)buffer;
-  response_message *resp = deserialize_response_message(buffer, bytes_read);
-  if (resp == NULL) {
-    const char *error_msg = "Failed to deserialize response";
-    *out = strdup(error_msg);
-    *out_size = strlen(error_msg) + 1;
-    *ret = -1;
-    return -1;
-  }
-
-  // Validate the response_message structure
-  if (resp->msg == NULL ||
-      (size_t)bytes_read < sizeof(response_message) + sizeof(message) ||
-      (size_t)bytes_read < sizeof(response_message) + resp->msg->length) {
-    const char *error_msg = "Invalid response structure";
-    *out = strdup(error_msg);
-    *out_size = strlen(error_msg) + 1;
-    *ret = -1;
-    return -1;
-  }
-
-  message *msg = resp->msg;
-  size_t value_size = msg->length - sizeof(message);
-
-  // Validate message length
-  if (msg->length < sizeof(message) ||
-      (size_t)bytes_read < sizeof(response_message) + msg->length) {
-    const char *error_msg = "Invalid message length";
-    *out = strdup(error_msg);
-    *out_size = strlen(error_msg) + 1;
-    *ret = -1;
-    return -1;
-  }
-
-  *out = (char *)malloc(value_size + 1);
-  if (*out == NULL) {
-    const char *error_msg = "Memory allocation failed";
-    *out = strdup(error_msg);
-    *out_size = strlen(error_msg) + 1;
-    *ret = -1;
-    free_response_message(resp);
-    return -1;
-  }
-
-  memcpy(*out, msg->value, value_size);
-  (*out)[value_size] = '\0';
-  *out_size = value_size + 1;
-
-  *ret = msg->type;
-
-  if (payload != NULL && payloadsz != NULL) {
-    if (resp->payload != NULL && resp->payloadsz > 0) {
-      *payload = malloc(resp->payloadsz);
-      if (*payload == NULL) {
-        const char *error_msg = "Memory allocation failed for payload";
-        free(*out);
+    msg = (message *)malloc(POVERLAY_BUFSIZE);
+    if (msg == NULL) {
+        const char *error_msg = "Memory allocation failed";
         *out = strdup(error_msg);
         *out_size = strlen(error_msg) + 1;
         *ret = -1;
-        free_response_message(resp);
         return -1;
-      }
-      memcpy(*payload, resp->payload, resp->payloadsz);
-      *payloadsz = resp->payloadsz;
-    } else {
-      *payload = NULL;
-      *payloadsz = 0;
     }
-  }
 
-  free_response_message(resp);
-  return 0;
+    bytes_read = read(fd, msg, POVERLAY_BUFSIZE);
+    if (bytes_read <= 0) {
+        const char *error_msg = (bytes_read == 0) ? "Connection closed" : "Read error";
+        free(msg);
+        *out = strdup(error_msg);
+        *out_size = strlen(error_msg) + 1;
+        *ret = -1;
+        return -1;
+    }
+
+    *out = (char *)malloc(msg->length);
+    memcpy(*out, msg->value, msg->length);
+    *out_size = msg->length;
+    *ret = msg->type;
+
+    free(msg); 
+    return 0;
 }
 
-int SendCall(int id /*IN*/, const char *path /*IN*/, int *ret /*OUT*/,
-             char **out /*OUT*/, size_t *out_size, void **reply_data,
-             size_t *reply_size) {
+// path contains the input argument(s). 
+int SendCall(int id, const char *path, int *ret, char **errm, size_t *errmsz) {
   int result;
   int sockfd;
 
   sockfd = -1;
   result = 0;
-  *out = NULL;
-  *out_size = 0;
+  *errm = NULL;
+  *errmsz = 0;
   *ret = 0;
 
-  // side effects: modify out, out_size, ret
-  sockfd = socket_connect(POVERLAY_SOCK_PATH, out, out_size, ret);
+  sockfd = socket_connect(POVERLAY_SOCK_PATH, errm, errmsz, ret);
   if (sockfd >= 0) {
-    // side effects: modify out, out_size, ret
-    if ((result = write_request(sockfd, id, path, out, out_size, ret)) == 0) {
-      // side effects: modify out, out_size, ret, reply_data, reply_size
-      result =
-          read_response(sockfd, out, out_size, ret, reply_data, reply_size);
+    if ((result = write_request(sockfd, id, path, errm, errmsz, ret)) == 0) {
+      result = read_response(sockfd, errm, errmsz, ret);
     }
     close(sockfd);
   } else {

--- a/pclsync/overlay_client.h
+++ b/pclsync/overlay_client.h
@@ -48,11 +48,9 @@ typedef enum _pCloud_FileState {
   FileStateInvalid
 } pCloud_FileState;
 
-int QueryState(pCloud_FileState *state /*OUT*/, char *path /*IN*/);
+int QueryState(pCloud_FileState *, char *);
+int SendCall(int id, const char *, int *, char **, size_t *);
 
-int SendCall(int id /*IN*/, const char *path /*IN*/, int *ret /*OUT*/,
-             char **out /*OUT*/, size_t *out_size, void **reply_data,
-             size_t *reply_size);
 #ifdef __cplusplus
 }
 #endif

--- a/pclsync/pfolder.c
+++ b/pclsync/pfolder.c
@@ -925,3 +925,4 @@ psync_folder_list_t *psync_list_get_list(char *syncTypes) {
 
   return ret;
 }
+

--- a/pclsync/poverlay.h
+++ b/pclsync/poverlay.h
@@ -49,8 +49,7 @@ extern int callbacks_running;
 
 void psync_overlay_main_loop(VOID);
 void psync_overlay_handle_request(LPVOID);
-void psync_overlay_get_response(request_message *rq /*IN*/,
-                                response_message *rs /*OUT*/);
+void psync_overlay_get_response(message*, message*);
 void psync_overlay_stop_overlays();
 void psync_overlay_start_overlays();
 void psync_overlay_stop_overlay_callbacks();
@@ -59,6 +58,6 @@ int psync_overlay_overlays_running();
 int psync_overlay_callbacks_running();
 
 void psync_overlay_init_callbacks();
-int psync_overlay_register_callback(int id, poverlay_callback callback);
+int psync_overlay_register_callback(int, poverlay_callback);
 
 #endif // POVERLAY_H

--- a/pclsync/poverlay_protocol.h
+++ b/pclsync/poverlay_protocol.h
@@ -10,22 +10,10 @@
 #define POVERLAY_SOCK_PATH "/tmp/pcloud_unix_soc.sock"
 #endif
 
-
 typedef struct _message {
   uint32_t type;
   uint64_t length;
   char value[];
 } message;
-
-// represents a request message
-typedef message request_message;
-
-// represents a response message; this includes the API response
-// message and any payload data returned by the callback function.
-typedef struct {
-  void *payload;    // data returned by the callback function
-  size_t payloadsz; // size of payload
-  message *msg;     // API response message
-} response_message;
 
 #endif

--- a/pclsync/pshm.c
+++ b/pclsync/pshm.c
@@ -1,0 +1,129 @@
+#include <sys/ipc.h>
+#include <sys/shm.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <limits.h>
+#include <stdbool.h>
+#include <errno.h>
+
+#include "debug.h"
+
+#include "pshm.h"
+
+key_t pshm_get_key() {
+    char path[PATH_MAX];
+    char *home;
+    
+    home = getenv("HOME");
+    if (home == NULL) {
+        debug(D_ERROR, "HOME environment variable is not set");
+        return (key_t)-1;
+    }
+    snprintf(path, sizeof(path), "%s/.pcloud/data.db", home);
+
+    return ftok(path, 'A');
+}
+
+int pshm_getid() {
+	key_t key;
+
+	key = pshm_get_key();
+	if(key == -1) {
+		debug(D_ERROR, "failed to get ipc key");
+		return -1;
+	}
+
+	return shmget(key, PSYNC_SHM_SIZE, IPC_CREAT | 0666);
+}
+
+bool pshm_read(void **data, size_t *datasz) {
+    int shmid;
+    psync_shm *shm;
+    int flag;
+    char *dataArea;
+
+    shmid = pshm_getid();
+    if (shmid == -1) {
+        debug(D_ERROR, "Failed to get shared memory ID");
+        return false;
+    }
+
+    shm = (psync_shm*)shmat(shmid, NULL, 0);
+    if (shm == (void*)-1) {
+        debug(D_ERROR, "Failed to attach to shared memory: %s", strerror(errno));
+        return false;
+    }
+
+    __atomic_load(&shm->flag, &flag, __ATOMIC_SEQ_CST);
+    if(flag != 1) {
+        shmdt(shm);
+        return false;
+    }
+
+    if(datasz != NULL) {
+        *datasz = shm->datasz;
+    }
+
+    *data = malloc(shm->datasz);
+    if(*data == NULL) {
+        debug(D_ERROR, "Failed to allocate memory for shared data");
+        shmdt(shm);
+        return false;
+    }
+
+    dataArea = (char *)shm + sizeof(psync_shm);
+    memcpy(*data, dataArea, shm->datasz);
+    
+    __atomic_store_n(&shm->flag, 0, __ATOMIC_SEQ_CST);
+
+    shmdt(shm);
+    return true;
+}
+
+void pshm_write(const void *data, size_t datasz) {
+    int shmid;
+    psync_shm* shm;
+    char *dataArea;
+    
+    if (datasz > PSYNC_SHM_SIZE - sizeof(psync_shm)) {
+        debug(D_ERROR, "Data size exceeds available shared memory size");
+        return;
+    }
+
+    shmid = pshm_getid();
+    if (shmid == -1) {
+        debug(D_ERROR, "Failed to get shared memory ID");
+        return;
+    }
+
+    shm = (psync_shm*)shmat(shmid, NULL, 0);
+    if (shm == (void*)-1) {
+        debug(D_ERROR, "Failed to attach to shared memory: %s", strerror(errno));
+        return;
+    }
+
+    if (shm->flag == 0 && shm->datasz == 0) {
+        debug(D_NOTICE, "Initializing shared memory segment");
+        // Clear the structure first
+        memset(shm, 0, sizeof(psync_shm));
+        // Data area starts right after the structure
+        shm->data = (char *)shm + sizeof(psync_shm);
+        shm->datasz = 0;
+        shm->flag = 0;
+    }
+
+    dataArea = (char *)shm + sizeof(psync_shm);
+    memcpy(dataArea, data, datasz);
+
+    shm->datasz = datasz;
+    __atomic_store_n(&shm->flag, 1, __ATOMIC_SEQ_CST);
+    
+    if (shmdt(shm) == -1) {
+        debug(D_ERROR, "Failed to detach from shared memory: %s", strerror(errno));
+    }
+}
+
+int pshm_cleanup() {
+	return shmctl(pshm_getid(), IPC_RMID, NULL);
+}

--- a/pclsync/pshm.h
+++ b/pclsync/pshm.h
@@ -1,0 +1,33 @@
+#ifndef __PSHM_H
+
+#define __PSHM_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <sys/ipc.h>
+
+#define PSYNC_SHM_SIZE 4096
+
+// shm is used to get the return values from the underlying pcloud functions
+// called by the overlay client. this is needed for cases such as
+// list_sync_folders, where the result should be presented to the user in the
+// CLI.
+typedef struct _psync_shm {
+  void *data;         // overlay callback return value
+  size_t datasz;      // overlay return value size
+  volatile int flag;  // new data available
+} psync_shm;
+
+void pshm_write(const void *data, size_t datasz);
+bool pshm_read(void **data, size_t *datasz);
+int pshm_cleanup();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/pclsync/psynclib.c
+++ b/pclsync/psynclib.c
@@ -71,6 +71,7 @@
 #include "ppathstatus.h"
 #include "pscanner.h"
 #include "psettings.h"
+#include "pshm.h"
 #include "pssl.h"
 #include "pstatus.h"
 #include "psyncer.h"
@@ -355,6 +356,9 @@ uint32_t psync_download_state() { return 0; }
 
 void psync_destroy() {
   psync_do_run = 0;
+  if (pshm_cleanup() == -1) {
+    debug(D_ERROR, "failed to cleanup shm");
+  }
   psync_fs_stop();
   psync_terminate_status_waiters();
   psync_send_status_update();

--- a/pclsync/psynclib.h
+++ b/pclsync/psynclib.h
@@ -1809,7 +1809,7 @@ void psync_get_folder_ownerid(psync_folderid_t folderid,
 //   void** pointer is null, then do not write any data back out for
 //   the client.
 //
-typedef int (*poverlay_callback)(const char *, void **);
+typedef int (*poverlay_callback)(const char *);
 
 /* Registers file manager extension callback that will be called when packet
  * with id equals to the give one had arrived from extension. The id must be

--- a/pclsync_lib.h
+++ b/pclsync_lib.h
@@ -29,11 +29,12 @@
 /*
   Dependencies:
   - <string>
-  - pclsync_lib_c.h
 */
 
 #ifndef PCLSYNC_LIB_H
 #define PCLSYNC_LIB_H
+
+#include <string>
 
 struct pstatus_struct_;
 typedef void (*status_callback_t)(int status, const char *stat_string);

--- a/pclsync_lib.h
+++ b/pclsync_lib.h
@@ -89,12 +89,12 @@ public:
   int init();
   // std::string& username, std::string& password, std::string*
   // crypto_pass, int setup_crypto = 1, int usesrypto_userpass = 0);
-  static int start_crypto(const char *pass, void **rep);
-  static int stop_crypto(const char *path, void **rep);
-  static int finalize(const char *path, void **rep);
-  static int list_sync_folders(const char *path, void **rep);
-  static int add_sync_folder(const char *path, void **rep);
-  static int remove_sync_folder(const char *path, void **rep);
+  static int start_crypto(const char *pass);
+  static int stop_crypto(const char *path);
+  static int finalize(const char *path);
+  static int list_sync_folders(const char *path);
+  static int add_sync_folder(const char *path);
+  static int remove_sync_folder(const char *path);
 
   char *get_token();
   int logout();
@@ -107,6 +107,7 @@ private:
   std::string tfa_code_;
   std::string crypto_pass_;
   std::string mount_;
+
 
   bool to_set_mount_;
   bool daemon_;


### PR DESCRIPTION
This PR reverts the messaging to handle API requests and responses only, by removing the "payload" structures that previously stored the return values for underlying overlay callback functions. Instead, use shared memory. The "pshm" functions implement read, write, and cleanup logic for a shared address space that the CLI and the API service can both use. The API service writes to pshm (the overlay callback return values, when needed), and the CLI reads from it and presents the result to the user.
