### PR TITLE
84 security enhancements

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -117,7 +117,7 @@ int main(int argc, char **argv) {
 
     cc::clibrary::pclsync_lib::get_lib().set_username(username);
     if (passwordsw) {
-      cc::clibrary::pclsync_lib::get_lib().get_pass_from_console();
+      cc::clibrary::pclsync_lib::get_lib().read_password();
     }
     cc::clibrary::pclsync_lib::get_lib().set_tfa_code(tfa_code);
     cc::clibrary::pclsync_lib::get_lib().set_trusted_device(trusted_device);
@@ -127,7 +127,7 @@ int main(int argc, char **argv) {
         cc::clibrary::pclsync_lib::get_lib().set_crypto_pass(password);
       } else {
         std::cout << "Enter crypto password." << std::endl;
-        cc::clibrary::pclsync_lib::get_lib().get_cryptopass_from_console();
+        cc::clibrary::pclsync_lib::get_lib().read_cryptopass();
       }
     } else
       cc::clibrary::pclsync_lib::get_lib().setup_crypto_ = false;

--- a/pclsync/pcrypto.c
+++ b/pclsync/pcrypto.c
@@ -36,7 +36,6 @@
 #include <mbedtls/ssl.h>
 #include <pthread.h>
 
-#include "pfile.h"
 #include "pcompiler.h"
 
 #include "pssl.h"
@@ -68,7 +67,7 @@ static void psync_hmac_sha512_init(psync_hmac_sha512_ctx *ctx,
   }
   psync_sha512_init(&ctx->sha1ctx);
   psync_sha512_update(&ctx->sha1ctx, keyxor, PSYNC_SHA512_BLOCK_LEN);
-  pssl_memclean(keyxor, PSYNC_SHA512_BLOCK_LEN);
+  putil_wipe(keyxor, PSYNC_SHA512_BLOCK_LEN);
 }
 
 static void psync_hmac_sha512_update(psync_hmac_sha512_ctx *ctx,
@@ -81,7 +80,7 @@ static void psync_hmac_sha512_final(unsigned char *result,
   psync_sha512_final(ctx->final + PSYNC_SHA512_BLOCK_LEN, &ctx->sha1ctx);
   psync_sha512(ctx->final, PSYNC_SHA512_BLOCK_LEN + PSYNC_SHA512_DIGEST_LEN,
                result);
-  pssl_memclean(ctx->final,
+  putil_wipe(ctx->final,
                      PSYNC_SHA512_BLOCK_LEN + PSYNC_SHA512_DIGEST_LEN);
 }
 
@@ -107,8 +106,8 @@ static void psync_hmac_sha512(const unsigned char *msg, size_t msglen,
   psync_sha512_update(&sha1ctx, msg, msglen);
   psync_sha512_final(final + PSYNC_SHA512_BLOCK_LEN, &sha1ctx);
   psync_sha512(final, PSYNC_SHA512_BLOCK_LEN + PSYNC_SHA512_DIGEST_LEN, result);
-  pssl_memclean(keyxor, PSYNC_SHA512_BLOCK_LEN);
-  pssl_memclean(final, PSYNC_SHA512_BLOCK_LEN + PSYNC_SHA512_DIGEST_LEN);
+  putil_wipe(keyxor, PSYNC_SHA512_BLOCK_LEN);
+  putil_wipe(final, PSYNC_SHA512_BLOCK_LEN + PSYNC_SHA512_DIGEST_LEN);
 }
 
 #define ALIGN_A256_BS(n)                                                       \
@@ -193,7 +192,7 @@ pcrypto_ctr_encdec_t pcrypto_ctr_encdec_create(psync_symmetric_key_t key) {
 void pcrypto_ctr_encdec_free(
     pcrypto_ctr_encdec_t enc) {
   paes_free_encoder(enc->encoder);
-  pssl_memclean(enc->iv, PSYNC_AES256_BLOCK_SIZE);
+  putil_wipe(enc->iv, PSYNC_AES256_BLOCK_SIZE);
   psync_free(enc);
 }
 
@@ -419,7 +418,7 @@ pcrypto_textenc_create(psync_symmetric_key_t key) {
 void pcrypto_textenc_free(
     pcrypto_textenc_t enc) {
   paes_free_encoder(enc->encoder);
-  pssl_memclean(enc->iv, enc->ivlen);
+  putil_wipe(enc->iv, enc->ivlen);
   pmemlock_free(enc);
 }
 
@@ -445,7 +444,7 @@ pcrypto_textdec_create(psync_symmetric_key_t key) {
 void pcrypto_textdec_free(
     pcrypto_textdec_t enc) {
   paes_free_encoder(enc->encoder);
-  pssl_memclean(enc->iv, enc->ivlen);
+  putil_wipe(enc->iv, enc->ivlen);
   pmemlock_free(enc);
 }
 
@@ -478,7 +477,7 @@ void pcrypto_sec_encdec_free(
     pcrypto_sector_encdec_t enc) {
   paes_free_encoder(enc->encoder);
   paes_free_decoder(enc->decoder);
-  pssl_memclean(enc->iv, enc->ivlen);
+  putil_wipe(enc->iv, enc->ivlen);
   pmemlock_free(enc);
 }
 

--- a/pclsync/pcryptofolder.c
+++ b/pclsync/pcryptofolder.c
@@ -271,6 +271,7 @@ static int download_keys(unsigned char **rsapriv, size_t *rsaprivlen, unsigned c
     break;
   default:
   def1:
+    putil_wipe(rsaprivstruct, rsaprivstructlen);
     psync_free(rsaprivstruct);
     psync_free(rsapubstruct);
     return PRINT_RETURN_CONST(PSYNC_CRYPTO_START_UNKNOWN_KEY_FORMAT);
@@ -292,10 +293,12 @@ static int download_keys(unsigned char **rsapriv, size_t *rsaprivlen, unsigned c
   default:
   def2:
     psync_free(*rsapub);
+    putil_wipe(rsaprivstruct, rsaprivstructlen);  
     psync_free(rsaprivstruct);
     psync_free(rsapubstruct);
     return PRINT_RETURN_CONST(PSYNC_CRYPTO_START_UNKNOWN_KEY_FORMAT);
   }
+  putil_wipe(rsaprivstruct, rsaprivstructlen);  
   psync_free(rsaprivstruct);
   psync_free(rsapubstruct);
   return PSYNC_CRYPTO_START_SUCCESS;
@@ -591,6 +594,7 @@ int pcryptofolder_unlock(const char *password) {
     if (unlikely(rowcnt != 0)) {
       debug(D_BUG,
             "only some of records found in the database, should not happen");
+      putil_wipe(rsapriv, rsaprivlen);  
       psync_free(rsapriv);
       psync_free(rsapub);
       psync_free(salt);
@@ -614,8 +618,10 @@ int pcryptofolder_unlock(const char *password) {
   if (crypto_pubkey == PSYNC_INVALID_RSA) {
     pthread_rwlock_unlock(&crypto_lock);
     debug(D_WARNING, "could not load public key");
+    putil_wipe(rsapriv, rsaprivlen);    
     psync_free(rsapriv);
     psync_free(rsapub);
+    putil_wipe(salt, saltlen);  
     psync_free(salt);
     return PRINT_RETURN_CONST(PSYNC_CRYPTO_START_UNKNOWN_KEY_FORMAT);
   }
@@ -641,8 +647,10 @@ int pcryptofolder_unlock(const char *password) {
     prsa_free_public(crypto_pubkey);
     crypto_pubkey = PSYNC_INVALID_RSA;
     pthread_rwlock_unlock(&crypto_lock);
+    putil_wipe(rsapriv, rsaprivlen);
     psync_free(rsapriv);
     psync_free(rsapub);
+    putil_wipe(salt, saltlen);
     psync_free(salt);
     return PRINT_RETURN_CONST(PSYNC_CRYPTO_START_BAD_PASSWORD);
   }
@@ -656,8 +664,10 @@ int pcryptofolder_unlock(const char *password) {
     crypto_privkey = PSYNC_INVALID_RSA;
     pthread_rwlock_unlock(&crypto_lock);
     debug(D_ERROR, "keys don't match");
+    putil_wipe(rsapriv, rsaprivlen);
     psync_free(rsapriv);
     psync_free(rsapub);
+    putil_wipe(salt, saltlen);
     psync_free(salt);
     return PRINT_RETURN_CONST(PSYNC_CRYPTO_START_KEYS_DONT_MATCH);
   }
@@ -672,8 +682,10 @@ int pcryptofolder_unlock(const char *password) {
                                         salt, saltlen, iterations, 0,
                                         publicsha1, privatesha1, flags);
   }
+  putil_wipe(rsapriv, rsaprivlen);  
   psync_free(rsapriv);
   psync_free(rsapub);
+  putil_wipe(salt, saltlen);
   psync_free(salt);
   debug(D_NOTICE, "crypto successfully started");
   return PSYNC_CRYPTO_START_SUCCESS;
@@ -1954,6 +1966,7 @@ int psync_pcloud_crypto_encode_key(const char *newpassphrase, uint32_t flags,
   psync_sha256(newpriv, rsaprivlen, newprivsha);
   rsasign = prsa_sign_sha256_hash(crypto_privkey, newprivsha);
   if (is_err(rsasign)) {
+    putil_wipe(newpriv, rsaprivlen);
     psync_free(newpriv);
     prsa_free_binary(rsapriv);
     return to_err(rsasign);
@@ -1961,6 +1974,7 @@ int psync_pcloud_crypto_encode_key(const char *newpassphrase, uint32_t flags,
   *privenc = (char *)psync_base64_encode(newpriv, rsaprivlen, &dummy);
   *sign = (char *)psync_base64_encode(rsasign->data, rsasign->datalen, &dummy);
   psync_free(rsasign);
+  putil_wipe(newpriv, rsaprivlen);
   psync_free(newpriv);
   prsa_free_binary(rsapriv);
 
@@ -2017,6 +2031,7 @@ int pcryptofolder_change_pass(const char *oldpassphrase,
         memset(privatekey_struct, 0, offsetof(priv_key_ver1, key) + privkeylen);
         memcpy(privatekey_struct->key, privkey, privkeylen);
         privatekey_struct->type = PSYNC_CRYPTO_TYPE_RSA4096_64BYTESALT_20000IT;
+        putil_wipe(privkey, privkeylen);
         psync_free(privkey);
       } else if (!strcmp(id, "crypto_public_key")) {
         load_str_to(&row[1], &pubkey, &pubkeylen);
@@ -2034,6 +2049,7 @@ int pcryptofolder_change_pass(const char *oldpassphrase,
           continue;
         }
         memcpy(privatekey_struct->salt, salt, saltlen);
+        putil_wipe(salt, saltlen);
         psync_free(salt);
       }
     }
@@ -2081,7 +2097,9 @@ int pcryptofolder_change_pass(const char *oldpassphrase,
         pubkey, pubkeylen, privkey, privkeylen, oldpassphrase, newpassphrase,
         flags, privenc, sign);
     psync_free(pubkey);
+    putil_wipe(privkey, privkeylen);    
     psync_free(privkey);
+    putil_wipe(salt, saltlen);    
     psync_free(salt);
     if (cres)
       goto ex;
@@ -2092,6 +2110,7 @@ int pcryptofolder_change_pass(const char *oldpassphrase,
         (unsigned char *)privatekey_struct,
         privkeylen + offsetof(priv_key_ver1, key), oldpassphrase, newpassphrase,
         flags, privenc, sign);
+    putil_wipe(privatekey_struct, privkeylen + offsetof(priv_key_ver1, key));    
     psync_free(privatekey_struct);
     psync_free(pubkey_struct);
     if (cres)

--- a/pclsync/pcryptofolder.c
+++ b/pclsync/pcryptofolder.c
@@ -634,7 +634,7 @@ int pcryptofolder_unlock(const char *password) {
 
   debug(D_NOTICE, "trying to load private key");
   crypto_privkey = prsa_load_private(rsaprivdec, rsaprivlen);
-  pssl_memclean(rsaprivdec, rsaprivlen);
+  putil_wipe(rsaprivdec, rsaprivlen);
   pmemlock_free(rsaprivdec);
   if (crypto_privkey == PSYNC_INVALID_RSA) {
     debug(D_NOTICE, "failed to load private key");
@@ -1704,7 +1704,7 @@ char *pcryptofolder_filencoder_key_new(uint32_t flags, size_t *keylen) {
     debug(D_ERROR, "RSA encryption failed");
     return (char *)errptr(PRINT_RETURN_CONST(PSYNC_CRYPTO_RSA_ERROR));
   }
-  pssl_memclean(&sym, sizeof(sym));
+  putil_wipe(&sym, sizeof(sym));
   ret = (char *)psync_base64_encode(encsym->data, encsym->datalen, keylen);
   psync_free(encsym);
   return ret;
@@ -1734,7 +1734,7 @@ char *pcryptofolder_filencoder_key_newplain(
     return (char *)errptr(PRINT_RETURN_CONST(PSYNC_CRYPTO_RSA_ERROR));
   }
   *deckey = symkeyv1_to_symkey(&sym);
-  pssl_memclean(&sym, sizeof(sym));
+  putil_wipe(&sym, sizeof(sym));
   ret = (char *)psync_base64_encode(encsym->data, encsym->datalen, keylen);
   psync_free(encsym);
   return ret;
@@ -1762,7 +1762,7 @@ int pcryptofolder_mkdir(psync_folderid_t folderid, const char *name,
   }
   encsym = prsa_encrypt_data(crypto_pubkey, (unsigned char *)&sym,
                                       sizeof(sym));
-  pssl_memclean(&sym, sizeof(sym));
+  putil_wipe(&sym, sizeof(sym));
   ret = get_fldr_name(folderid, name, &ename, err);
   pthread_rwlock_unlock(&crypto_lock);
   if (ret) {
@@ -1864,7 +1864,7 @@ int psync_pcloud_crypto_reencode_key(
     pcrypto_ctr_encdec_free(enc);
     newprivlen = offsetof(priv_key_ver1, key) + rsaprivlen;
     priv = prsa_load_private(rsaprivdec, rsaprivlen);
-    pssl_memclean(rsaprivdec, rsaprivlen);
+    putil_wipe(rsaprivdec, rsaprivlen);
     psync_free(rsaprivdec);
     if (unlikely(priv == PSYNC_INVALID_RSA))
       goto err_ph_1;

--- a/pclsync/pnetlibs.c
+++ b/pclsync/pnetlibs.c
@@ -2583,14 +2583,14 @@ int psync_get_upload_checksum(psync_uploadid_t uploadid, unsigned char *uhash,
   return PSYNC_NET_OK;
 }
 
-void psync_logout2(uint32_t auth_status, int doinvauth);
-
-static void logout2_thread() { psync_logout2(PSTATUS_AUTH_BADTOKEN, 0); }
+static void proc_logout() { 
+  psync_logout(PSTATUS_AUTH_BADTOKEN, 0); 
+}
 
 // this is called when ANY api call returns non zero result
 void psync_process_api_error(uint64_t result) {
   if (result == 2000)
-    prun_thread("logout from process_api_error", logout2_thread);
+    prun_thread("logout from process_api_error", proc_logout);
 }
 
 static void psync_netlibs_timer(psync_timer_t timer, void *ptr) {

--- a/pclsync/ppassword.c
+++ b/pclsync/ppassword.c
@@ -39,6 +39,7 @@
 #include "ppassword.h"
 #include "ppassworddict.h"
 #include "pssl.h"
+#include "putil.h"
 #include <ctype.h>
 #include <string.h>
 
@@ -351,8 +352,8 @@ uint64_t ppassword_score(const char *cpassword) {
       ldpwd[nlen] = lpwd[nlen];
   }
   num = score_variants(password, lpwd, ldpwd, plen);
-  pssl_memclean(lpwd, plen);
-  pssl_memclean(ldpwd, plen);
+  putil_wipe(lpwd, plen);
+  putil_wipe(ldpwd, plen);
   psync_free(lpwd);
   psync_free(ldpwd);
   mul_score(num);

--- a/pclsync/pssl.h
+++ b/pclsync/pssl.h
@@ -149,7 +149,6 @@ typedef psync_encrypted_data_t psync_rsa_signature_t;
 // Lock used to serialize access to RSA decrypt key function
 
 int pssl_init();
-void pssl_memclean(void *ptr, size_t len);
 int pssl_connect(int sock, void **sslconn, const char *hostname);
 int pssl_connect_finish(void *sslconn, const char *hostname);
 void pssl_free(void *sslconn);

--- a/pclsync/psynclib.h
+++ b/pclsync/psynclib.h
@@ -638,7 +638,7 @@ char *psync_get_username();
 void psync_set_user_pass(const char *username, const char *password, int save);
 void psync_set_pass(const char *password, int save);
 void psync_set_auth(const char *auth, int save);
-void psync_logout();
+void psync_logout(uint32_t auth_status, int doinvauth);
 void psync_unlink();
 
 /* Upon seein a status of PSTATUS_TFA_REQUIRED the application is supposed to

--- a/pclsync/putil.c
+++ b/pclsync/putil.c
@@ -1,0 +1,35 @@
+#include <errno.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/random.h>
+
+#include "plibs.h"
+
+// wipe a segment of memory mem of size sz using a DoD 5220.22-M compliant
+// 3-pass wipe. the first pass overwrites the memory with zeroes, the second
+// with ones, and the third with random data using the urandom entropy
+// source. if the urandom source fails, it falls back to a simple
+// (non-cryptographically-secure) RNG.
+void putil_wipe(void *mem, size_t sz) {
+    if (!mem || sz == 0) { return; }
+
+    volatile unsigned char *p = (volatile unsigned char *)mem;
+
+    memset((void*)p, 0x00, sz);
+    memset((void*)p, 0xFF, sz);
+
+    ssize_t result = getrandom((void*)p, sz, 0);
+    if (result != (ssize_t)sz) {
+        if (result == -1) {
+            debug(D_WARNING, "getrandom() failed: %s.", strerror(errno));
+        } else {
+            debug(D_WARNING, "getrandom() returned partial data.");
+        }
+
+        debug(D_WARNING, "falling back to less secure third pass. This may occur due to insufficient entropy, early boot state, or kernel incompatibility.");
+        srand((unsigned int)(time(NULL) ^ (uintptr_t)&srand));
+		for (size_t i = 0; i < sz; i++) {
+		    p[i] = (unsigned char)rand();
+		}
+    }
+}

--- a/pclsync/putil.h
+++ b/pclsync/putil.h
@@ -1,3 +1,12 @@
+#ifndef __PUTIL_H
+#define __PUTIL_H
+
+#include <stddef.h>
+
 #define NTO_STR(s) TO_STR(s)
 #define TO_STR(s) #s
 #define VAR_ARRAY(name, type, size) type name[size]
+
+void putil_wipe(void *mem, size_t sz);
+
+#endif

--- a/pclsync/putil.h
+++ b/pclsync/putil.h
@@ -1,6 +1,10 @@
 #ifndef __PUTIL_H
 #define __PUTIL_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <stddef.h>
 
 #define NTO_STR(s) TO_STR(s)
@@ -8,5 +12,9 @@
 #define VAR_ARRAY(name, type, size) type name[size]
 
 void putil_wipe(void *mem, size_t sz);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/pclsync_lib.h
+++ b/pclsync_lib.h
@@ -68,7 +68,6 @@ public:
   void set_trusted_device(bool arg);
   void set_tfa_code(const std::string& arg);
   void set_username(const std::string &arg);
-  void set_password(const std::string &arg);
   void set_crypto_pass(const std::string &arg);
   void set_mount(const std::string &arg);
   void set_savepass(bool s);
@@ -87,9 +86,9 @@ public:
   static pclsync_lib &get_lib();
 
   // Console
-  void get_tfa_code_from_console();
-  void get_pass_from_console();
-  void get_cryptopass_from_console();
+  void read_tfa_code();
+  void read_password();
+  void read_cryptopass();
 
   // API calls
   int init();
@@ -118,8 +117,8 @@ private:
   bool to_set_mount_;
   bool daemon_;
 
-  void do_get_pass_from_console(std::string &password);
-  void wipe(std::string& str);
+  void read_from_stdin(std::string &s);
+  void wipe(std::string& s);
 };
 } // namespace clibrary
 } // namespace console_client

--- a/pclsync_lib.h
+++ b/pclsync_lib.h
@@ -77,6 +77,12 @@ public:
   void set_daemon(bool p);
   void set_status_callback(status_callback_t p);
 
+  // FIXME: not ideal, better if programmer does not have to remember to do
+  // this, but good enough for now...
+  void wipe_password();
+  void wipe_crypto_pass();
+  void wipe_tfa_code();
+
   // Singleton
   static pclsync_lib &get_lib();
 
@@ -103,9 +109,9 @@ public:
 
 private:
   std::string username_;
-  std::string password_;
-  std::string tfa_code_;
-  std::string crypto_pass_;
+  std::string password_;    // SENSITIVE, use wipe function
+  std::string tfa_code_;    // SENSITIVE, use wipe function
+  std::string crypto_pass_; // SENSITIVE, use wipe function
   std::string mount_;
 
 
@@ -113,6 +119,7 @@ private:
   bool daemon_;
 
   void do_get_pass_from_console(std::string &password);
+  void wipe(std::string& str);
 };
 } // namespace clibrary
 } // namespace console_client

--- a/rpcclient.cpp
+++ b/rpcclient.cpp
@@ -11,6 +11,7 @@
 #include "rpcclient.h"
 #include "plibs.h"
 #include "prpc.h"
+#include "putil.h"
 
 
 #define POVERLAY_BUFSIZE 512
@@ -97,12 +98,12 @@ int RpcClient::writeRequest(int fd, int msgtype, const char *value, char **out, 
     writeerr = POVERLAY_WRITE_COMM_ERR;
   }
 
+  putil_wipe(buf, size);
   free(buf);
   return writeerr;
 }
 
 int RpcClient::readResponse(int fd, char **out, size_t *out_size) {
-
     rpc_message_t *msg = (rpc_message_t *)malloc(POVERLAY_BUFSIZE);
     if (msg == NULL) {
         const char *error_msg = "Memory allocation failed";
@@ -116,6 +117,7 @@ int RpcClient::readResponse(int fd, char **out, size_t *out_size) {
         const char *error_msg = (bytes_read == 0) ? "Connection closed" : "Read error";
         *out = strdup(error_msg);
         *out_size = strlen(error_msg) + 1;
+        putil_wipe(msg, POVERLAY_BUFSIZE);
         free(msg);
         return -1;
     }
@@ -124,6 +126,7 @@ int RpcClient::readResponse(int fd, char **out, size_t *out_size) {
     memcpy(*out, msg->value, msg->length);
     *out_size = msg->length;
 
+    putil_wipe(msg, POVERLAY_BUFSIZE);
     free(msg); 
     return 0;
 }


### PR DESCRIPTION
- DoD 5220.22-M compliant memory wipe replaces single-pass zero wipe
- Wipe in-memory request and response messages before freeing
- Wipe in-memory private keys and salt data before freeing
- Wipe all passwords on unlink / logout
- Wipe crypto password on all `pcryptofolder_unlock` return paths
