### PR TITLE
fix: add stdlib to fix build

### DIFF
--- a/pclsync/pdevice.c
+++ b/pclsync/pdevice.c
@@ -31,6 +31,7 @@
 
 #include <dirent.h>
 #include <fcntl.h>
+#include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 

--- a/pclsync/prun.c
+++ b/pclsync/prun.c
@@ -1,4 +1,5 @@
 #include <pthread.h>
+#include <stdlib.h>
 
 #include "psettings.h"
 #include "prun.h"


### PR DESCRIPTION
Hi again 🙂 ,
on my system, pcloudcc would not compile, because the `stdlib.h` include was missing in two files (`pdevice.c` and `prun.c`). The error looked like this:
```
gcc -fPIC  -I./pclsync -I/usr/include -O2 -DNDEBUG -D_FILE_OFFSET_BITS=64 -DFUSE_USE_VERSION=26 -D_GNU_SOURCE -DPSYNC_SSL_DEBUG_LEVEL=0  -c -o pdevice.o pclsync/pdevice.c
pclsync/pdevice.c: In function ‘pdevice_id’:
pclsync/pdevice.c:63:9: error: implicit declaration of function ‘free’ [-Wimplicit-function-declaration]
   63 |         free(path);
      |         ^~~~
pclsync/pdevice.c:40:1: note: include ‘<stdlib.h>’ or provide a declaration of ‘free’
   39 | #include "putil.h"
  +++ |+#include <stdlib.h>
   40 |
pclsync/pdevice.c:63:9: warning: incompatible implicit declaration of built-in function ‘free’ [-Wbuiltin-declaration-mismatch]
   63 |         free(path);
      |         ^~~~
pclsync/pdevice.c:63:9: note: include ‘<stdlib.h>’ or provide a declaration of ‘free’
pclsync/pdevice.c: In function ‘pdevice_name’:
pclsync/pdevice.c:83:3: warning: incompatible implicit declaration of built-in function ‘free’ [-Wbuiltin-declaration-mismatch]
   83 |   free(osname);
      |   ^~~~
pclsync/pdevice.c:83:3: note: include ‘<stdlib.h>’ or provide a declaration of ‘free’
make: *** [Makefile:80: pdevice.o] Error 1
```

I added the stdlib again and the build ran smoothly from then on. Possibly you want to have these added in your repository as well. 🙂 

Cheers and happy holidays!