### PR TITLE
Fix #8: Add pending transfer check feature

### DIFF
--- a/pclsync/pcommands.h
+++ b/pclsync/pcommands.h
@@ -4,5 +4,6 @@ enum command_ids_ {
   FINALIZE,
   LISTSYNC,
   ADDSYNC,
-  STOPSYNC
+  STOPSYNC,
+  CHECKPENDING
 };

--- a/pclsync_lib.h
+++ b/pclsync_lib.h
@@ -97,6 +97,7 @@ public:
   static int start_crypto(const char *pass);
   static int stop_crypto(const char *path);
   static int finalize(const char *path);
+  static int check_pending(const char *unused);
   static int list_sync_folders(const char *path);
   static int add_sync_folder(const char *path);
   static int remove_sync_folder(const char *path);


### PR DESCRIPTION
## Summary
Implements Issue #8 - adds ability to check for pending transfers before shutting down the daemon.

## Changes
- Add new `pending` command (alias `p`) to check for pending transfers
- Enhance `finalize` command to warn about pending transfers before shutdown
- Client prompts for confirmation in interactive mode
- Uses `psync_get_status()` API for reliable transfer detection
- Communicates via shared memory between daemon and client
- Shows separate upload/download counts

## Testing
- `pending` command shows current transfer status
- `finalize` warns if transfers are pending and prompts for confirmation
- User can cancel shutdown to avoid breaking transfers

Closes #8