### PR TITLE
Fix exception handling and operator precedence bugs

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -214,6 +214,7 @@ int main(int argc, char **argv) {
     return 1;
   } catch (...) {
     std::cerr << "Exception of unknown type!" << std::endl;
+    return 1;
   }
 
   if (daemon) {

--- a/rpcclient.cpp
+++ b/rpcclient.cpp
@@ -135,7 +135,7 @@ int RpcClient::GetState(pCloud_FileState *state, char *path) {
   size_t errm_size = 0;
   int rep = 0;
 
-  if ((rep = this->Call(4, path, &errm, &errm_size) == 0)) {
+  if ((rep = this->Call(4, path, &errm, &errm_size)) == 0) {
     pdbg_logf(D_NOTICE, "rpc_get_state responese rep[%d] path[%s]", rep, path);
     if (errm) {
       pdbg_logf(D_NOTICE, "The error is %s", errm);


### PR DESCRIPTION
Two critical bug fixes:

**Exception handling (main.cpp:216)**
- Added missing return statement in catch(...) block
- Prevents daemon startup with uninitialized state after unknown exceptions

**Operator precedence (rpcclient.cpp:138)**
- Fixed assignment/comparison precedence in GetState()
- Was: `rep = this->Call(...) == 0` (assigns boolean)
- Now: `(rep = this->Call(...)) == 0` (assigns Call() return value)
- Fixes file state always returning FileStateInvalid

Fixes #201, #202