### PR TITLE
Fix MAP_FAILED detection in pmem_mmap_safe

### DIFF
--- a/pclsync/pmem.c
+++ b/pclsync/pmem.c
@@ -6,8 +6,9 @@
 
 void *pmem_mmap(size_t size) {
 #if defined(MAP_ANONYMOUS)
-  return mmap(NULL, size, PROT_READ | PROT_WRITE,
-              MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  void *ret = mmap(NULL, size, PROT_READ | PROT_WRITE,
+                   MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  return (ret == MAP_FAILED) ? NULL : ret;
 #else
   return malloc(size);
 #endif


### PR DESCRIPTION
mmap(2) returns MAP_FAILED ((void*)-1) on error, not NULL. The check 'if (likely(ret))' treats MAP_FAILED as truthy, so the emergency retry path is never reached and callers receive MAP_FAILED as a valid pointer.

Compare ret against MAP_FAILED for mmap paths and NULL for malloc paths.

Fixes #226