### PR TITLE
Fix data race on excepions in ptimer_do_notify_exception

### DIFF
--- a/pclsync/ptimer.c
+++ b/pclsync/ptimer.c
@@ -266,9 +266,9 @@ void ptimer_sleep_handler(psync_exception_callback func) {
 void ptimer_do_notify_exception() {
   struct exception_list *e;
   pthread_t threadid;
-  e = excepions;
   threadid = pthread_self();
   pthread_mutex_lock(&timer_ex_mutex);
+  e = excepions;
   while (e) {
     if (!pthread_equal(threadid, e->threadid))
       e->func();


### PR DESCRIPTION
excepions is read without holding timer_ex_mutex, but ptimer_exception_handler() modifies it under the mutex.

Move the read inside the critical section to prevent the race.

Fixes #227