### PR TITLE
Fix typo: rename psync_list_bulder_* to psync_list_builder_*

### DIFF
--- a/pclsync/plist.c
+++ b/pclsync/plist.c
@@ -160,7 +160,7 @@ psync_list_builder_t *psync_list_builder_create(size_t element_size, size_t offs
   return builder;
 }
 
-uint32_t *psync_list_bulder_push_num(psync_list_builder_t *builder) {
+uint32_t *psync_list_builder_push_num(psync_list_builder_t *builder) {
   if (!builder->last_numbers ||
       builder->last_numbers->used >=
           sizeof(builder->last_numbers->numbers) / sizeof(uint32_t)) {
@@ -172,7 +172,7 @@ uint32_t *psync_list_bulder_push_num(psync_list_builder_t *builder) {
   return &builder->last_numbers->numbers[builder->last_numbers->used++];
 }
 
-uint32_t psync_list_bulder_pop_num(psync_list_builder_t *builder) {
+uint32_t psync_list_builder_pop_num(psync_list_builder_t *builder) {
   uint32_t ret;
   ret = builder->last_numbers->numbers[builder->popoff++];
   if (builder->popoff >= builder->last_numbers->used) {
@@ -184,7 +184,7 @@ uint32_t psync_list_bulder_pop_num(psync_list_builder_t *builder) {
 }
 
 
-void *psync_list_bulder_add_element(psync_list_builder_t *builder) {
+void *psync_list_builder_add_element(psync_list_builder_t *builder) {
   if (!builder->last_elements ||
       builder->last_elements->used >= builder->elements_per_list) {
     builder->last_elements = (psync_list_element_list *)malloc(
@@ -196,7 +196,7 @@ void *psync_list_bulder_add_element(psync_list_builder_t *builder) {
   builder->current_element =
       builder->last_elements->elements +
       builder->last_elements->used * builder->element_size;
-  builder->cstrcnt = psync_list_bulder_push_num(builder);
+  builder->cstrcnt = psync_list_builder_push_num(builder);
   *builder->cstrcnt = 0;
   builder->last_elements->used++;
   builder->cnt++;
@@ -229,8 +229,8 @@ void psync_list_add_lstring_offset(psync_list_builder_t *builder, size_t offset,
   }
   memcpy(s, *str, length);
   *str = s;
-  *(psync_list_bulder_push_num(builder)) = offset;
-  *(psync_list_bulder_push_num(builder)) = length;
+  *(psync_list_builder_push_num(builder)) = offset;
+  *(psync_list_builder_push_num(builder)) = length;
   (*builder->cstrcnt)++;
 }
 
@@ -268,10 +268,10 @@ void *psync_list_builder_finalize(psync_list_builder_t *builder) {
     for (i = 0; i < el->used; i++) {
       memcpy(elem, el->elements + (i * builder->element_size),
              builder->element_size);
-      scnt = psync_list_bulder_pop_num(builder);
+      scnt = psync_list_builder_pop_num(builder);
       for (j = 0; j < scnt; j++) {
-        offset = psync_list_bulder_pop_num(builder);
-        length = psync_list_bulder_pop_num(builder);
+        offset = psync_list_builder_pop_num(builder);
+        length = psync_list_builder_pop_num(builder);
         pstr = (char **)(elem + offset);
         memcpy(str, *pstr, length);
         *pstr = str;

--- a/pclsync/plist.h
+++ b/pclsync/plist.h
@@ -146,10 +146,10 @@ static inline psync_list *psync_list_remove_head(psync_list *l) {
 
 void psync_list_sort(psync_list *l, psync_list_compare cmp);
 void psync_list_extract_repeating(psync_list *l1, psync_list *l2, psync_list *extracted1, psync_list *extracted2, psync_list_compare cmp);
-uint32_t *psync_list_bulder_push_num(psync_list_builder_t *builder);
-uint32_t psync_list_bulder_pop_num(psync_list_builder_t *builder);
+uint32_t *psync_list_builder_push_num(psync_list_builder_t *builder);
+uint32_t psync_list_builder_pop_num(psync_list_builder_t *builder);
 psync_list_builder_t *psync_list_builder_create(size_t element_size, size_t offset);
-void *psync_list_bulder_add_element(psync_list_builder_t *builder);
+void *psync_list_builder_add_element(psync_list_builder_t *builder);
 void psync_list_add_string_offset(psync_list_builder_t *builder, size_t offset);
 void psync_list_add_lstring_offset(psync_list_builder_t *builder, size_t offset, size_t length);
 void *psync_list_builder_finalize(psync_list_builder_t *builder);

--- a/pclsync/pnotify.c
+++ b/pclsync/pnotify.c
@@ -315,7 +315,7 @@ psync_notification_list_t *pnotify_get() {
     cnttotal = notifications->length;
     for (i = 0; i < cnttotal; i++) {
       ntf = notifications->array[i];
-      pntf = (psync_notification_t *)psync_list_bulder_add_element(builder);
+      pntf = (psync_notification_t *)psync_list_builder_add_element(builder);
       br = papi_find_result2(ntf, "notification", PARAM_STR);
       pntf->text = br->str;
       psync_list_add_lstring_offset(

--- a/pclsync/psql.c
+++ b/pclsync/psql.c
@@ -316,7 +316,7 @@ void psql_list_add(psync_list_builder_t *builder, psync_sql_res *res, psync_list
     builder->current_element =
         builder->last_elements->elements +
         builder->last_elements->used * builder->element_size;
-    builder->cstrcnt = psync_list_bulder_push_num(builder);
+    builder->cstrcnt = psync_list_builder_push_num(builder);
     *builder->cstrcnt = 0;
     while (callback(builder, builder->current_element, row)) {
       row = psql_fetch(res);

--- a/pclsync/psynclib.c
+++ b/pclsync/psynclib.c
@@ -412,7 +412,7 @@ apiservers_list_t *psync_get_apiservers(char **err) {
 
   for (i = 0; i < locationscnt; ++i) {
     location = locations->array[i];
-    plocation = (apiserver_info_t *)psync_list_bulder_add_element(builder);
+    plocation = (apiserver_info_t *)psync_list_builder_add_element(builder);
     br = papi_find_result2(location, "label", PARAM_STR);
     plocation->label = br->str;
     psync_list_add_lstring_offset(builder, offsetof(apiserver_info_t, label),
@@ -606,7 +606,7 @@ int psync_tfa_send_nofification(plogged_device_list_t **devices_list) {
           sizeof(plogged_device_t), offsetof(plogged_device_list_t, devices));
       for (i = 0; i < cres->length; i++) {
         plogged_device_t *dev =
-            (plogged_device_t *)psync_list_bulder_add_element(builder);
+            (plogged_device_t *)psync_list_builder_add_element(builder);
         const binresult *str =
             papi_find_result2(cres->array[i], "name", PARAM_STR);
         dev->type = papi_find_result2(cres->array[i], "type", PARAM_NUM)->num;

--- a/pclsync/publiclinks.c
+++ b/pclsync/publiclinks.c
@@ -1157,7 +1157,7 @@ plink_contents_t *do_show_link(const char *code, char **err /*OUT*/) {
                                         offsetof(plink_contents_t, entries));
     for (i = 0; i < concnt; ++i) {
       link = contents->array[i];
-      pcont = (link_cont_t *)psync_list_bulder_add_element(builder);
+      pcont = (link_cont_t *)psync_list_builder_add_element(builder);
       br = papi_find_result2(link, "name", PARAM_STR);
       pcont->name = br->str;
       psync_list_add_lstring_offset(builder, offsetof(link_cont_t, name),
@@ -1454,7 +1454,7 @@ preciever_list_t *do_list_email_with_access(unsigned long long linkid,
   }
   for (i = 0; i < lcnt; ++i) {
     reciever = list->array[i];
-    pcont = (reciever_info_t *)psync_list_bulder_add_element(builder);
+    pcont = (reciever_info_t *)psync_list_builder_add_element(builder);
     br = papi_find_result2(reciever, "email", PARAM_STR);
     if (br) {
       pcont->mail = br->str;
@@ -1575,7 +1575,7 @@ bookmarks_list_t *do_cache_bookmarks(char **err) {
 
   for (i = 0; i < lcnt; ++i) {
     bookmark = list->array[i];
-    pcont = (bookmark_info_t *)psync_list_bulder_add_element(builder);
+    pcont = (bookmark_info_t *)psync_list_builder_add_element(builder);
     br = papi_find_result2(bookmark, "link", PARAM_STR);
     pcont->link = br->str;
     psync_list_add_lstring_offset(builder, offsetof(bookmark_info_t, link),


### PR DESCRIPTION
Three functions had a consistent typo (missing 'i' in builder):
- psync_list_bulder_push_num
- psync_list_bulder_pop_num
- psync_list_bulder_add_element

Renamed to correct spelling in plist.h, plist.c, and all callers.

Fixes #219