### PR TITLE
Fix swapped struct sizes in pqevent_queue_sync_event_path

### DIFF
--- a/pclsync/pqevent.c
+++ b/pclsync/pqevent.c
@@ -376,9 +376,9 @@ void pqevent_queue_sync_event_path(psync_eventtype_t eventid, psync_syncid_t syn
     llen = strlen(localpath) + 1;
     rlen = strlen(remotepath) + 1;
     if (eventid & PEVENT_TYPE_FOLDER)
-      slen = sizeof(psync_file_event_t);
-    else
       slen = sizeof(psync_folder_event_t);
+    else
+      slen = sizeof(psync_file_event_t);
     event =
         (event_list_t *)malloc(sizeof(event_list_t) + slen + llen + rlen);
     strct = (char *)(event + 1);


### PR DESCRIPTION
When eventid has PEVENT_TYPE_FOLDER set, the code allocated psync_file_event_t size but cast to psync_folder_event_t.

Swap the sizeof() calls to match the actual struct types used.

Fixes #229