### PR TITLE
Fix unchecked malloc in papi_result_async

### DIFF
--- a/pclsync/papi.c
+++ b/pclsync/papi.c
@@ -460,6 +460,11 @@ again:
       reader->bytesread = 0;
       reader->bytestoread = reader->respsize;
       reader->data = (unsigned char *)malloc(reader->respsize);
+      if (!reader->data) {
+        reader->result = NULL;
+        papi_rdr_alloc(reader);
+        return ASYNC_RES_READY;
+      }
       goto again;
     } else {
       pdbg_assert(reader->state == 1);


### PR DESCRIPTION
reader->data = malloc(reader->respsize) at line 462 is not checked for NULL before goto again continues the loop and dereferences it.

Add NULL check and return ASYNC_RES_READY with result=NULL on failure.

Fixes #238