### PR TITLE
Fix use-after-free: heap-allocate socket fd for RPC threads

### DIFF
--- a/pclsync/prpc.c
+++ b/pclsync/prpc.c
@@ -122,6 +122,7 @@ static void on_request(void *lpvParam) {
 cleanup:
   if (sockfd) {
     close(*sockfd);
+    free(sockfd);
   }
   if (response) {
     free(response);
@@ -265,10 +266,18 @@ void prpc_main_loop() {
       continue;
     }
 
+    int *cl_ptr = malloc(sizeof(int));
+    if (!cl_ptr) {
+      pdbg_logf(D_ERROR, "Failed to allocate memory for socket fd");
+      close(cl);
+      continue;
+    }
+    *cl_ptr = cl;
+
     // handle the request in a new thread
     prun_thread1("Pipe request handle routine",
                       on_request, // thread proc
-                      (void *)&cl                   // thread parameter
+                      (void *)cl_ptr                   // thread parameter
     );
   }
 


### PR DESCRIPTION
Fixes #236

**Issue:** Stack variable `cl` in `prpc_main_loop()` is passed by address to threads via `prun_thread1(..., &cl)`. The thread dereferences it in `on_request()` after the stack frame may be reused by the next `accept()` call, causing use-after-free or reading the wrong fd.

**Fix:** 
- Heap-allocate the socket fd before passing to thread
- Free it in `on_request()` cleanup path after `close()`

**Testing:** Daemon starts, RPC commands work