### PR TITLE
Add MAX_API_RESPONSE_SIZE bounds check in papi.c

### DIFF
--- a/pclsync/papi.c
+++ b/pclsync/papi.c
@@ -28,6 +28,8 @@
 */
 
 #include <stddef.h>
+
+#define MAX_API_RESPONSE_SIZE (256 * 1024 * 1024) // 256MB
 #include <stdio.h>
 #include <string.h>
 
@@ -393,6 +395,12 @@ binresult *papi_result(psock_t *sock) {
 
   if (pdbg_unlikely(psock_readall(sock, &ressize, sizeof(uint32_t)) !=
                    sizeof(uint32_t))) {
+    return NULL;
+  }
+
+  if (ressize > MAX_API_RESPONSE_SIZE) {
+    pdbg_logf(D_WARNING, "API response size %u exceeds limit %u, rejecting",
+              ressize, MAX_API_RESPONSE_SIZE);
     return NULL;
   }
 


### PR DESCRIPTION
Fixes #245

**Issue:** In `papi.c:394-404`, `ressize` is read from socket and passed directly to `malloc()` with no upper-bound check. Malicious server can send huge size causing OOM or DoS.

**Fix:** 
- Define `MAX_API_RESPONSE_SIZE` (256MB)
- Reject responses exceeding limit before allocation

**Testing:** Daemon starts, API calls work