### PR TITLE
Fix ptevent: memory leak, NULL-deref, and race condition

### DIFF
--- a/pclsync/ptevent.c
+++ b/pclsync/ptevent.c
@@ -1,7 +1,9 @@
 #include "pdbg.h"
 #include "prun.h"
 #include "ptevent.h"
+#include <pthread.h>
 
+static pthread_mutex_t data_event_fptr_mutex = PTHREAD_MUTEX_INITIALIZER;
 data_event_callback data_event_fptr = NULL;
 
 static void proc_send_data_event(void *ptr) {
@@ -12,27 +14,39 @@ static void proc_send_data_event(void *ptr) {
         "Uint2:[%lu]",
         data->eventid, data->str1, data->str2, data->uint1, data->uint2);
 
-  data_event_fptr(data->eventid, (char *)data->str1, (char *)data->str2,
-                  data->uint1, data->uint2);
+  pthread_mutex_lock(&data_event_fptr_mutex);
+  if (data_event_fptr) {
+    data_event_fptr(data->eventid, (char *)data->str1, (char *)data->str2,
+                    data->uint1, data->uint2);
+  }
+  pthread_mutex_unlock(&data_event_fptr_mutex);
 
+  free((void *)data->str1);
+  free((void *)data->str2);
   free(ptr);
 }
 
 void ptevent_init(void *ptr) {
+  pthread_mutex_lock(&data_event_fptr_mutex);
   data_event_fptr = (data_event_callback)ptr;
+  pthread_mutex_unlock(&data_event_fptr_mutex);
   pdbg_logf(D_NOTICE, "Data event handler set.");
 }
 
 void ptevent_process(event_data_struct *data) {
   event_data_struct *event_data;
 
-  if (data_event_fptr) {
+  pthread_mutex_lock(&data_event_fptr_mutex);
+  int has_callback = (data_event_fptr != NULL);
+  pthread_mutex_unlock(&data_event_fptr_mutex);
+
+  if (has_callback) {
     event_data = malloc(sizeof(event_data_struct));
     event_data->eventid = data->eventid;
     event_data->uint1 = data->uint1;
     event_data->uint2 = data->uint2;
-    event_data->str1 = strdup(data->str1);
-    event_data->str2 = strdup(data->str2);
+    event_data->str1 = data->str1 ? strdup(data->str1) : NULL;
+    event_data->str2 = data->str2 ? strdup(data->str2) : NULL;
 
     prun_thread1("Data Event", proc_send_data_event, event_data);
   } else {


### PR DESCRIPTION
Fixes #228

**Issues:**
1. Memory leak: `str1` and `str2` allocated in `ptevent_process()` but not freed in `proc_send_data_event()`
2. NULL-deref: `strdup(NULL)` is UB if `data->str1` or `data->str2` is NULL
3. Race condition: `data_event_fptr` written in `ptevent_init()` and read in `proc_send_data_event()` with no synchronization

**Fixes:**
- Free `str1` and `str2` after callback
- Add NULL guards before `strdup()`
- Protect `data_event_fptr` with mutex

**Testing:** Clean build