### PR TITLE
Replace sprintf with snprintf in ptools.c

### DIFF
--- a/pclsync/ptools.c
+++ b/pclsync/ptools.c
@@ -139,7 +139,7 @@ int ptools_create_backend_event(const char *binapi, const char *category,
         strcat(keyParams, params->Params[i].paramname);
       }
 
-      sprintf(charBuff[i], "key%s", params->Params[i].paramname);
+      snprintf(charBuff[i], sizeof(charBuff[i]), "key%s", params->Params[i].paramname);
 
       if (params->Params[i].paramtype == 0) {
         paramsLocal[mpCnt + i] =


### PR DESCRIPTION
Fixes #217

**Issue:** `sprintf(charBuff[i], "key%s", params->Params[i].paramname)` at line 142 can overflow if `paramname` is longer than 254 bytes. `charBuff[i]` is 258 bytes.

**Fix:** Replace `sprintf` with `snprintf` to prevent overflow.

**Note:** The bead also mentions checking `strcat(keyParams, ...)` bounds. `keyParams` is allocated as `258 * pCnt` bytes which should be sufficient for comma-separated paramnames, but could add explicit check if needed.

**Testing:** Clean build