### PR TITLE
Fix ptree_for_each_element loop termination condition

### DIFF
--- a/pclsync/ptree.h
+++ b/pclsync/ptree.h
@@ -49,8 +49,9 @@ typedef struct _psync_tree {
 #define ptree_for_each(a, l)                                              \
   for (a = ptree_get_first(l); a != NULL; a = ptree_get_next(a))
 #define ptree_for_each_element(a, l, t, n)                                \
-  for (a = ptree_element(ptree_get_first(l), t, n); &a->n != NULL;   \
-       a = ptree_element(ptree_get_next(&a->n), t, n))
+  for (a = (ptree_get_first(l) ? ptree_element(ptree_get_first(l), t, n) : NULL); \
+       a != NULL;                                                              \
+       a = (ptree_get_next(&a->n) ? ptree_element(ptree_get_next(&a->n), t, n) : NULL))
 
 #define ptree_for_each_element_call(l, t, n, c)                           \
   do {                                                                         \


### PR DESCRIPTION
Fixes #213

**Issue:** Loop condition `&a->n != NULL` tests the address of a struct member, which is always non-NULL for valid pointers. When `ptree_get_next()` returns NULL, `ptree_element(NULL, t, n)` produces a pointer at `-offsetof(t,n)`, which is non-NULL unless `n` is the first member of `t`. The macro only terminates correctly when `offsetof(t,n)==0`; for any other layout it dereferences garbage or runs forever.

**Fix:** Check `a != NULL` instead of `&a->n != NULL`, and handle NULL returns from `ptree_get_first()` and `ptree_get_next()` before calling `ptree_element()`.

**Testing:** Clean build, daemon starts