### PR TITLE
Add bounds check in trim_der_key() before memcpy

### DIFF
--- a/pclsync/pssl.c
+++ b/pclsync/pssl.c
@@ -620,6 +620,13 @@ static void trim_der_key(unsigned char *keydata, size_t *keylen) {
     }
     header_size = p - keydata;
     correct_len = header_size + len;
+    if (correct_len > *keylen) {
+        pdbg_logf(D_ERROR, "ASN.1 length %zu exceeds buffer size %zu", correct_len, *keylen);
+        return;
+    }
+    if (correct_len > *keylen) {
+        return;
+    }
     trimmed = malloc(correct_len);
     if (!trimmed) return;
     memcpy(trimmed, keydata, correct_len);


### PR DESCRIPTION
Fixes #237

**Issue:** `trim_der_key()` computes `correct_len = header_size + len` from ASN.1 parsing but does not verify `correct_len <= *keylen` before `memcpy(trimmed, keydata, correct_len)`. If the ASN.1 length field is corrupted or malicious, `correct_len` can exceed the actual buffer size, causing out-of-bounds read.

**Fix:** Add `if (correct_len > *keylen) return;` before malloc/memcpy.

**Testing:** Clean build, daemon starts with TLS