### PR TITLE
Fix integer overflow in prpc.c response->length calculation

### DIFF
--- a/pclsync/prpc.c
+++ b/pclsync/prpc.c
@@ -219,12 +219,12 @@ static void respond(rpc_message_t *request, rpc_message_t *response) {
 
   // truncate messages that exceed the buffer boundaries
   size_t value_length = strnlen(response->value, value_avail);
-  response->length = sizeof(rpc_message_t) + value_length + 1;
-  if (response->length > POVERLAY_BUFSIZE) {
-    response->length = POVERLAY_BUFSIZE;
-    response->value[value_avail - 1] = '\0';
+  if (value_length > POVERLAY_BUFSIZE - sizeof(rpc_message_t) - 1) {
+    value_length = POVERLAY_BUFSIZE - sizeof(rpc_message_t) - 1;
+    response->value[value_length] = '\0';
     pdbg_logf(D_WARNING, "Response message truncated to fit buffer");
   }
+  response->length = sizeof(rpc_message_t) + value_length + 1;
 }
 
 void prpc_main_loop() {


### PR DESCRIPTION
Fixes #246

**Issue:** `response->length = sizeof(rpc_message_t) + value_length + 1` at line 221 can overflow if `value_length` is large. The overflow happens before the `POVERLAY_BUFSIZE` check, causing incorrect length calculation.

**Fix:** Check `value_length` against `POVERLAY_BUFSIZE - sizeof(rpc_message_t) - 1` before computing `response->length`. Truncate value if needed, then compute length safely.

**Testing:** Clean build, daemon starts, RPC commands work