### PR TITLE
Add POVERLAY_BUFSIZE bounds check in prpc.c read loop

### DIFF
--- a/pclsync/prpc.c
+++ b/pclsync/prpc.c
@@ -86,6 +86,11 @@ static void on_request(void *lpvParam) {
     rqbufp = rqbufp + rc;
     if (readbytes > 12) {
       request = (rpc_message_t *)rqbuf;
+      if (request->length > POVERLAY_BUFSIZE) {
+        pdbg_logf(D_ERROR, "Request length %lu exceeds buffer size %d",
+                  (unsigned long)request->length, POVERLAY_BUFSIZE);
+        goto cleanup;
+      }
       if (request->length == (uint64_t)readbytes)
         break;
     }


### PR DESCRIPTION
Fixes #247

**Issue:** The read loop at lines 84-92 accumulates bytes into a `POVERLAY_BUFSIZE` buffer but does not validate `request->length` after casting at line 88. If a malicious client sends `request->length > POVERLAY_BUFSIZE`, the loop continues reading until `readbytes == request->length`, writing past the buffer end.

**Fix:** Check `request->length <= POVERLAY_BUFSIZE` after casting and before continuing to read. Log error and abort on oversized requests.

**Testing:** Clean build, daemon starts, RPC commands work