### PR TITLE
Add upper bound check in check_peer_pubkey()

### DIFF
--- a/pclsync/pssl.c
+++ b/pclsync/pssl.c
@@ -304,8 +304,9 @@ static int check_peer_pubkey(ssl_connection_t *conn) {
   }
   i = mbedtls_pk_write_pubkey_der((mbedtls_pk_context *)&cert->pk, buff,
                                   sizeof(buff));
-  if (i <= 0) {
-    pdbg_logf(D_WARNING, "pk_write_pubkey_der returned error %d", i);
+  if (i <= 0 || i > (int)sizeof(buff)) {
+    pdbg_logf(D_WARNING, "pk_write_pubkey_der returned %d (buffer size %zu)", 
+              i, sizeof(buff));
     return -1;
   }
   mbedtls_sha256(buff + sizeof(buff) - i, i, sigbin, 0);


### PR DESCRIPTION
Fixes #248

**Issue:** `mbedtls_pk_write_pubkey_der()` returns bytes written in `i`. Line 311 uses `buff + sizeof(buff) - i` without verifying `i <= sizeof(buff)`. If the key is larger than the 1024-byte buffer, `i > sizeof(buff)` produces invalid pointer arithmetic (negative offset).

**Fix:** Check `i <= (int)sizeof(buff)` after `mbedtls_pk_write_pubkey_der()`. Return error if key exceeds buffer size.

**Testing:** Clean build, daemon starts with TLS