### PR TITLE
Fix integer overflow in fake fileid calculation

### DIFF
--- a/pclsync/pfs.c
+++ b/pclsync/pfs.c
@@ -1389,8 +1389,10 @@ static int pfs_open(const char *path, struct fuse_file_info *fi) {
 
     } else { /* cr->fileid==0 */
       psync_fstask_local_creat_t *lc;
+      int64_t fake_fileid;
       lc = pfs_task_creat_get_local(cr);
-      of = pfs_create_file(INT64_MAX - (UINT64_MAX - cr->taskid), 0,
+      fake_fileid = INT64_MIN + (int64_t)cr->taskid;
+      of = pfs_create_file(fake_fileid, 0,
                                 lc->datalen, 0, 1, 0,
                                 pfs_task_get_ref_locked(folder),
                                 fpath->name, PSYNC_CRYPTO_INVALID_ENCODER);


### PR DESCRIPTION
Fixes #252

**Issue:** Line 1393 computes fake fileid as `INT64_MAX - (UINT64_MAX - cr->taskid)`. The expression `UINT64_MAX - cr->taskid` is unsigned arithmetic. When subtracted from signed `INT64_MAX`, this causes signed overflow (undefined behavior) if taskid is large.

**Fix:** Replace with `INT64_MIN + (int64_t)cr->taskid`, which uses only signed arithmetic and avoids overflow.

**Testing:** Clean build, daemon starts, filesystem operations work