### PR TITLE
Fix NULL-deref in pfs_rename_openfile_locked

### DIFF
--- a/pclsync/pfs.c
+++ b/pclsync/pfs.c
@@ -309,8 +309,13 @@ int pfs_rename_openfile_locked(psync_fsfileid_t fileid,
         fl->currentfolder =
             pfs_task_get_or_create_folder_tasks_locked(folderid);
       }
+      char *newname = putil_strdup(name);
+      if (!newname) {
+        pthread_mutex_unlock(&fl->mutex);
+        return -ENOMEM;
+      }
       free(fl->currentname);
-      fl->currentname = putil_strdup(name);
+      fl->currentname = newname;
       pthread_mutex_unlock(&fl->mutex);
       return 1;
     }


### PR DESCRIPTION
Fixes #260

**Issue:** Lines 311-312 do `free(fl->currentname)` then `fl->currentname = putil_strdup(name)` without checking if `putil_strdup` returns NULL. On OOM, `fl->currentname` becomes NULL and later dereferences (e.g., logging) will crash.

**Fix:** Check `putil_strdup` return before freeing old name. On failure, keep old name and return `-ENOMEM`.

**Testing:** Clean build, daemon starts, file rename operations work