### PR TITLE
Fix race condition in pfs_dec_of_refcnt

### DIFF
--- a/pclsync/pfs.c
+++ b/pclsync/pfs.c
@@ -1782,12 +1782,15 @@ void pfs_dec_of_refcnt(psync_openfile_t *of) {
   uint32_t refcnt;
   pfs_get_both_locks(of);
   refcnt = --of->refcnt;
-  if (!refcnt)
+  if (!refcnt) {
     ptree_del(&openfiles, &of->tree);
-  psql_unlock();
-  pthread_mutex_unlock(&of->mutex);
-  if (!refcnt)
+    psql_unlock();
+    pthread_mutex_unlock(&of->mutex);
     pfs_free_openfile(of);
+  } else {
+    psql_unlock();
+    pthread_mutex_unlock(&of->mutex);
+  }
 }
 
 void pfs_inc_of_refcnt_and_readers(psync_openfile_t *of) {


### PR DESCRIPTION
Fixes #257

**Issue:** `pfs_dec_of_refcnt()` decrements refcnt and removes openfile from tree at line 1786 while holding locks, then releases locks at lines 1787-1788, then calls `pfs_free_openfile(of)` at line 1790. Between unlock and free, another thread could access the freed struct.

**Fix:** Call `pfs_free_openfile()` before releasing locks. Unlock only after memory is freed.

**Testing:** Clean build, daemon starts, file operations work