### PR TITLE
Add authsave command to save authentication credentials

### DIFF
--- a/control_tools.cpp
+++ b/control_tools.cpp
@@ -73,6 +73,7 @@ static char* command_generator(const char* text, int state) {
     "status", "st",
     "tfa",
     "auth",
+    "authsave",
     "finalize", "f",
     "quit", "q",
     nullptr
@@ -120,6 +121,7 @@ void setup_app(CLI::App *app) {
               << "  status(st): Show current sync state" << std::endl
               << "  tfa <code>: Supply 2FA code to a running daemon" << std::endl
               << "  auth <password>: Supply password to a running daemon" << std::endl
+              << "  authsave <password>: Supply password and save to database" << std::endl
               << "  finalize(f): Kill daemon and quit" << std::endl
               << "  quit(q): Exit this program" << std::endl;
   });
@@ -206,6 +208,29 @@ void setup_app(CLI::App *app) {
     }
     delete rpc;
     std::cout << "Auth sent." << std::endl;
+    if (errm) { free(errm); }
+    return 0;
+  });
+
+  // authsave command
+  auto authsave_cmd = app->add_subcommand("authsave", "Supply password to a running daemon and save to database");
+  static std::string authsave_pass_input;
+  authsave_cmd->add_option("password", authsave_pass_input, "Password")->required();
+  authsave_cmd->callback([] {
+    char *errm = NULL;
+    size_t errm_size = 0;
+    RpcClient *rpc = new RpcClient();
+    int result = rpc->Call(SENDAUTHSAVE, authsave_pass_input.c_str(), &errm, &errm_size);
+    putil_wipe(authsave_pass_input.data(), authsave_pass_input.size());
+    authsave_pass_input.clear();
+    if (result != 0) {
+      std::cerr << "Failed to send auth: " << (errm ? errm : "no message") << std::endl;
+      if (errm) { free(errm); }
+      delete rpc;
+      return result;
+    }
+    delete rpc;
+    std::cout << "Auth sent and saved." << std::endl;
     if (errm) { free(errm); }
     return 0;
   });

--- a/pclsync/pcommands.h
+++ b/pclsync/pcommands.h
@@ -10,5 +10,6 @@ enum command_ids_ {
   SYNCRESUME,
   SENDTFA,
   SENDAUTH,
+  SENDAUTHSAVE,
   GETSTATUS
 };

--- a/pclsync_lib.cpp
+++ b/pclsync_lib.cpp
@@ -191,6 +191,16 @@ int clib::pclsync_lib::receive_auth(const char *pass) {
   return 0;
 }
 
+int clib::pclsync_lib::receive_auth_save(const char *pass) {
+  psync_set_pass(pass, 1);
+  pthread_mutex_lock(&auth_mtx);
+  get_lib().password_ = std::string(pass);
+  pthread_cond_signal(&auth_cond);
+  pthread_mutex_unlock(&auth_mtx);
+  std::cout << "Auth received and saved." << std::endl;
+  return 0;
+}
+
 void clib::pclsync_lib::read_tfa_code(bool auto_sms)
 {
   if (daemon_) {
@@ -713,6 +723,7 @@ int clib::pclsync_lib::init() {
   prpc_register(SYNCRESUME, &resume_sync);
   prpc_register(SENDTFA, &receive_tfa_code);
   prpc_register(SENDAUTH, &receive_auth);
+  prpc_register(SENDAUTHSAVE, &receive_auth_save);
   prpc_register(GETSTATUS, &get_status);
 
   return 0;

--- a/pclsync_lib.h
+++ b/pclsync_lib.h
@@ -106,6 +106,7 @@ public:
   static int resume_sync(const char *unused);
   static int receive_tfa_code(const char *code);
   static int receive_auth(const char *pass);
+  static int receive_auth_save(const char *pass);
   static int get_status(const char *unused);
 
   int logout();


### PR DESCRIPTION
Implement authsave command to persist authentication credentials.

Changes:
- Add AUTHSAVE command definition to pcommands.h
- Expose do_authsave() in pclsync_lib.h
- Implement do_authsave() in pclsync_lib.cpp
- Add authsave handler in control_tools.cpp

Commit: d7018dd