### PR TITLE
Fix authsave to save both username and password

### DIFF
--- a/pclsync_lib.cpp
+++ b/pclsync_lib.cpp
@@ -192,7 +192,8 @@ int clib::pclsync_lib::receive_auth(const char *pass) {
 }
 
 int clib::pclsync_lib::receive_auth_save(const char *pass) {
-  psync_set_pass(pass, 1);
+  const char *username = get_lib().username_.c_str();
+  psync_set_user_pass(username, pass, 1);
   pthread_mutex_lock(&auth_mtx);
   get_lib().password_ = std::string(pass);
   pthread_cond_signal(&auth_cond);


### PR DESCRIPTION
Update do_authsave() to call psync_set_user_pass() instead of psync_set_pass(), ensuring both username and password are persisted.

Commit: 732fefb