### PR TITLE
Remove Warnings

### DIFF
--- a/control_tools.cpp
+++ b/control_tools.cpp
@@ -545,6 +545,8 @@ int daemonize(bool do_commands) {
       break;
     }
   }
+
+  return 0;
 }
 
 } // namespace control_tools

--- a/pclsync/ppassword.c
+++ b/pclsync/ppassword.c
@@ -141,7 +141,7 @@ static uint64_t trailing_num_score(uint64_t num, size_t numlen,
 static int keyboard_buddies(int ch1, int ch2) {
   static const char *kb = "qwertyuiop[]asdfghjkl;'\\zxcvbnm,./"
                           "QWERTYUIOP{}ASDFGHJKL:\"|ZXCVBNM<>?~!@#$%^&*()_+";
-  char *f;
+  const char *f;
   f = strchr(kb, ch1);
   return f && (f[1] == ch2 || (f > kb && *(f - 1) == ch2));
 }


### PR DESCRIPTION
## Changes
- added a `const` qualifier in `keyboard_buddies` to resolve compilation warning
- added a `return 0` in `daemonize` to resolve a compilation warning
    - I am unsure if this is the correct thing to do

## Notes
- compiling w/ g++ 16.1.1 on fedora 44 aarch64
- I saw this while running the tests, I don't know if this is a problem

```
=== tests/test_pcl26j_free ===
PASS: request_range: pmem_free called with header ptr, not data ptr
PASS: synced_down_folder: pmem_free called with header ptr, not data ptr
PASS: folder_tasks: pmem_free called with header ptr, not data ptr
PASS: sector_inlog: pmem_free called with header ptr, not data ptr
BAD FREE: 0x232b4a50 was not a malloc-returned pointer
PASS: harness self-check: bare free(data_ptr) correctly flagged
```